### PR TITLE
[pipeline] Add trigger:mender-dist-packages job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ stages:
   - test
   - build
   - publish
+  - trigger
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
@@ -34,3 +35,18 @@ build:make:
     - apk add --update git make gcc pkgconfig libc-dev glib-dev
   script:
     - make build
+
+trigger:mender-dist-packages:
+  image: alpine
+  stage: trigger
+  before_script:
+    - apk add --no-cache curl
+  script:
+    - curl -v -f -X POST
+      -F token=$MENDER_DIST_PACKAGES_TRIGGER_TOKEN
+      -F ref=master
+      -F variables[MENDER_CONNECT_VERSION]=$CI_COMMIT_REF_NAME
+      https://gitlab.com/api/v4/projects/14968223/trigger/pipeline
+  only:
+    - tags
+    - master


### PR DESCRIPTION
To trigger a build of the APT repository on changes in mender-connect.