### PR TITLE
[examples/mender-connect.conf] Remove unnecessary ServerURL

### DIFF
--- a/examples/mender-connect.conf
+++ b/examples/mender-connect.conf
@@ -1,5 +1,4 @@
 {
-  "ServerURL": "https://hosted.mender.io",
   "ShellCommand": "/bin/bash",
   "User": "nobody"
 }


### PR DESCRIPTION
This parameter is not required, as the ServerURL is retrieved from the
mender client via D-Bus API.

Changelog: Title