### PR TITLE
1.0.x: [examples/mender-connect.conf] Remove unnecessary ServerURL

### DIFF
--- a/examples/mender-connect.conf
+++ b/examples/mender-connect.conf
@@ -1,5 +1,4 @@
 {
-  "ServerURL": "https://hosted.mender.io",
   "ShellCommand": "/bin/bash",
   "User": "nobody"
 }


### PR DESCRIPTION
This parameter is not required, as the ServerURL is retrieved from the
mender client via D-Bus API.

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 6ede6fea0b0d8955df3eccf208e010f532d1b009)