### PR TITLE
make use of gitlab triggers - relates to QA-315

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,6 @@ trigger:mender-qa:
 trigger:mender-dist-packages:
   stage: trigger
   rules:
-    - if: $CI_COMMIT_TAG
     - if: '$CI_COMMIT_BRANCH == "master"'
   variables:
     MENDER_CONNECT_VERSION: $CI_COMMIT_REF_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ stages:
   - test
   - build
   - publish
+  - trigger_prep
   - trigger
 
 include:
@@ -36,44 +37,52 @@ build:make:
   script:
     - make build
 
-trigger:mender-qa:
-  image: alpine
-  stage: trigger
+generate-qa-trigger:
+  image: python:alpine
+  stage: trigger_prep
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|[0-9]+\.[0-9]+\.x)$/'
+    - if: '$CI_PIPELINE_SOURCE == "pipeline"'
+      when: never
   before_script:
-    - apk add --no-cache git curl bash python3 py3-pip
+    - apk add --no-cache git
     - pip3 install pyyaml
-    - git clone https://github.com/mendersoftware/integration.git integration
-    - git clone https://github.com/mendersoftware/mender-qa.git mender-qa
+    - wget -q https://raw.githubusercontent.com/mendersoftware/mender-qa/master/scripts/generate_client_publish_job.py
   script:
-    - export WORKSPACE=$(pwd)
-    - mender-qa/scripts/gitlab_trigger_client_publish ${CI_COMMIT_REF_NAME} ${CI_PROJECT_NAME}
-  only:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/
+    - python generate_client_publish_job.py --trigger ${CI_PROJECT_NAME} --version ${CI_COMMIT_REF_NAME} --filename gitlab-ci-client-qemu-publish-job.yml
+  artifacts:
+    paths:
+      - gitlab-ci-client-qemu-publish-job.yml
+
+trigger:mender-qa:
+  stage: trigger
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|[0-9]+\.[0-9]+\.x)$/'
+    # the following is to prevent an endless loop of qa pipelines caused by downstream pipelines
+    - if: '$CI_PIPELINE_SOURCE == "pipeline"'
+      when: never
+  trigger:
+    include:
+      - artifact: gitlab-ci-client-qemu-publish-job.yml
+        job: generate-qa-trigger
 
 trigger:mender-dist-packages:
-  image: alpine
   stage: trigger
-  before_script:
-    - apk add --no-cache curl
-  script:
-    - curl -v -f -X POST
-      -F token=$MENDER_DIST_PACKAGES_TRIGGER_TOKEN
-      -F ref=master
-      -F variables[MENDER_CONNECT_VERSION]=$CI_COMMIT_REF_NAME
-      https://gitlab.com/api/v4/projects/14968223/trigger/pipeline
-  only:
-    - tags
-    - master
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_BRANCH == "master"'
+  variables:
+    MENDER_CONNECT_VERSION: $CI_COMMIT_REF_NAME
+  trigger:
+    project: Northern.tech/Mender/mender-dist-packages
+    branch: master
 
 trigger:integration:
-  image: alpine
   stage: trigger
-  before_script:
-    - apk add --no-cache curl
-  script:
-    - curl -v -f -X POST
-      -F token=$CI_TRIGGER_TOKEN_INTEGRATION
-      -F ref=master
-      https://gitlab.com/api/v4/projects/12670314/trigger/pipeline
-  only:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_PIPELINE_SOURCE == "pipeline"'
+      when: never
+  trigger:
+    project: Northern.tech/Mender/integration
+    branch: master


### PR DESCRIPTION
while working on QA-315 and to prevent costly trigger loops from appearing because of that, this switches the trigger jobs to use the gitlab native trigger functionality (which also allows easier pipeline navigation).

working triggering pipeline: https://gitlab.com/Northern.tech/Mender/mender-connect/-/pipelines/315074399
triggered pipelines (canceled as it was just for debug purposes):
 - [mender-qa](https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines/315079395)
 - [mender-dist-packages](https://gitlab.com/Northern.tech/Mender/mender-dist-packages/-/pipelines/315079397)
 - [integration](https://gitlab.com/Northern.tech/Mender/integration/-/pipelines/315079388)
 
 this depends on mendersoftware/mender-qa#506
 
also: coveralls is drunk!