### PR TITLE
MEN-4694 Break reconnection loop on auth lost

### DIFF
--- a/connectionmanager/connectionmanager.go
+++ b/connectionmanager/connectionmanager.go
@@ -45,6 +45,12 @@ var (
 	ErrConnectionRetriesExhausted = errors.New("failed to connect after max number of retries")
 )
 
+var (
+	reconnectingMutex   = sync.Mutex{}
+	reconnecting        = map[ws.ProtoType]bool{}
+	cancelReconnectChan = map[ws.ProtoType]chan bool{}
+)
+
 type ProtocolHandler struct {
 	proto      ws.ProtoType
 	connection *connection.Connection
@@ -73,9 +79,14 @@ func connect(proto ws.ProtoType, serverUrl, connectUrl, token string, skipVerify
 	scheme := getWebSocketScheme(parsedUrl.Scheme)
 	u := url.URL{Scheme: scheme, Host: parsedUrl.Host, Path: connectUrl}
 
+	cancelReconnectChan[proto] = make(chan bool)
 	var c *connection.Connection
 	var i uint = 0
-	for {
+	defer func() {
+		setReconnecting(proto, false)
+	}()
+	setReconnecting(proto, true)
+	for IsReconnecting(proto) {
 		i++
 		c, err = connection.NewConnection(u, token, writeWait, maxMessageSize, DefaultPingWait, skipVerify, serverCertificate)
 		if err != nil || c == nil {
@@ -87,6 +98,11 @@ func connect(proto ws.ProtoType, serverUrl, connectUrl, token string, skipVerify
 					"reconnecting in %ds (try %d/%d); len(token)=%d", serverUrl, connectUrl,
 					err.Error(), reconnectIntervalSeconds, i, retries, len(token))
 				select {
+				case cancelFlag := <-cancelReconnectChan[proto]:
+					log.Tracef("connectionmanager connect got cancelFlag=%+v", cancelFlag)
+					if cancelFlag {
+						return nil
+					}
 				case <-ctx.Done():
 					return nil
 				case <-time.After(time.Second * time.Duration(reconnectIntervalSeconds)):
@@ -107,6 +123,8 @@ func connect(proto ws.ProtoType, serverUrl, connectUrl, token string, skipVerify
 		connection: c,
 		mutex:      &sync.Mutex{},
 	}
+
+	log.Tracef("connectionmanager connect returning")
 	return nil
 }
 
@@ -162,7 +180,39 @@ func Write(proto ws.ProtoType, m *ws.ProtoMsg) error {
 	return h.connection.WriteMessage(m)
 }
 
+func IsReconnecting(proto ws.ProtoType) bool {
+	reconnectingMutex.Lock()
+	defer reconnectingMutex.Unlock()
+	return reconnecting[proto]
+}
+
+func setReconnecting(proto ws.ProtoType, v bool) bool {
+	reconnectingMutex.Lock()
+	defer reconnectingMutex.Unlock()
+	reconnecting[proto] = v
+	return v
+}
+
+func CancelReconnection(proto ws.ProtoType) {
+	maxWaitSeconds := 8
+	cancelReconnectChan[proto] <- true
+	for maxWaitSeconds > 0 {
+		time.Sleep(time.Second)
+		if !IsReconnecting(proto) {
+			break
+		}
+		maxWaitSeconds--
+	}
+	if IsReconnecting(proto) {
+		log.Error("failed to cancel reconnection")
+	}
+}
+
 func Close(proto ws.ProtoType) error {
+	if IsReconnecting(proto) {
+		CancelReconnection(proto)
+	}
+
 	handlersByTypeMutex.Lock()
 	defer handlersByTypeMutex.Unlock()
 


### PR DESCRIPTION
Changelog: MEN-4694: Handle the re-connection request even if there is
no new JWT token from the Mender client

Signed-off-by: Peter Grzybowski <peter@northern.tech>
(cherry picked from commit ea08acc12949d44e1b8a181f75c438b9930a29e9)
(cherry picked from commit f806a0f7a2ce6f06543a531b3c12af5549d3d183)