### PR TITLE
[MEN-4864] Try refreshing JWT token if server returns 401 (unauthorized)

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -55,7 +55,6 @@ type MenderShellDaemon struct {
 	writeMutex              *sync.Mutex
 	eventChan               chan MenderShellDaemonEvent
 	connectionEstChan       chan MenderShellDaemonEvent
-	reconnectChan           chan MenderShellDaemonEvent
 	stop                    bool
 	authorized              bool
 	printStatus             bool
@@ -111,9 +110,8 @@ func NewDaemon(conf *config.MenderShellConfig) *MenderShellDaemon {
 		ctx:                     ctx,
 		ctxCancel:               ctxCancel,
 		writeMutex:              &sync.Mutex{},
-		eventChan:               make(chan MenderShellDaemonEvent),
+		eventChan:               make(chan MenderShellDaemonEvent, 1),
 		connectionEstChan:       make(chan MenderShellDaemonEvent),
-		reconnectChan:           make(chan MenderShellDaemonEvent),
 		stop:                    false,
 		authorized:              false,
 		username:                conf.User,
@@ -225,7 +223,7 @@ func (d *MenderShellDaemon) messageLoop() (err error) {
 				event: EventReconnectRequest,
 			}
 			log.Tracef("messageLoop: posting event: %s; waiting for response", e.event)
-			d.reconnectChan <- e
+			d.eventChan <- e
 			response := <-d.connectionEstChan
 			log.Tracef("messageLoop: got response: %+v", response)
 			continue
@@ -264,9 +262,9 @@ func (d *MenderShellDaemon) gotAuthToken(p []dbus.SignalParams, needsReconnect b
 	jwtTokenLength := len(jwtToken)
 	if jwtTokenLength > 0 {
 		if !d.authorized {
-			log.Tracef("dbusEventLoop: StateChanged from unauthorized"+
+			log.Tracef("eventLoop: StateChanged from unauthorized"+
 				" to authorized, len(token)=%d", jwtTokenLength)
-			//in hereT technically it is possible we close a closed connection
+			//in here technically it is possible we close a closed connection
 			//but it is not a critical error, the important thing is not to leave
 			//messageLoop waiting forever on readMessage
 			connectionmanager.Close(ws.ProtoTypeShell)
@@ -283,14 +281,14 @@ func (d *MenderShellDaemon) gotAuthToken(p []dbus.SignalParams, needsReconnect b
 		d.authorized = true
 	} else {
 		if d.authorized {
-			log.Tracef("dbusEventLoop: StateChanged from authorized to unauthorized." +
+			log.Tracef("eventLoop: StateChanged from authorized to unauthorized." +
 				"terminating all sessions and disconnecting.")
 			shellsCount, sessionsCount, err := session.MenderSessionTerminateAll()
 			if err == nil {
-				log.Infof("dbusEventLoop terminated %d sessions, %d shells",
+				log.Infof("eventLoop terminated %d sessions, %d shells",
 					shellsCount, sessionsCount)
 			} else {
-				log.Errorf("dbusEventLoop error terminating all sessions: %s",
+				log.Errorf("eventLoop error terminating all sessions: %s",
 					err.Error())
 			}
 		}
@@ -300,51 +298,94 @@ func (d *MenderShellDaemon) gotAuthToken(p []dbus.SignalParams, needsReconnect b
 	return jwtToken
 }
 
-func (d *MenderShellDaemon) needsReconnect() bool {
-	select {
-	case e := <-d.reconnectChan:
-		log.Tracef("needsReconnect: got event: %s", e.event)
-		return true
-	case <-time.After(time.Second):
-		return false
-	}
-}
-
-func (d *MenderShellDaemon) dbusEventLoop(client mender.AuthClient) {
+func (d *MenderShellDaemon) eventLoop(client mender.AuthClient) {
+	var err error
 	needsReconnect := false
+	done := d.ctx.Done()
+	tokenChan := client.GetJwtTokenStateChangeChannel()
+EventLoop:
 	for {
-		if d.shouldStop() {
-			break
-		}
+		select {
+		case <-done:
+			break EventLoop
 
-		if d.needsReconnect() {
-			log.Trace("dbusEventLoop: daemon needs to reconnect")
-			needsReconnect = true
-		}
+		case p := <-tokenChan:
+			if len(p) > 0 && p[0].ParamType == dbus.GDBusTypeString {
+				token := d.gotAuthToken(p, needsReconnect)
+				if len(token) > 0 {
+					log.Tracef("eventLoop: got a token len=%d", len(token))
+					needsReconnect = false
+				}
+			}
 
-		p, _ := client.WaitForJwtTokenStateChange()
-		if len(p) > 0 && p[0].ParamType == dbus.GDBusTypeString {
-			token := d.gotAuthToken(p, needsReconnect)
-			if len(token) > 0 {
-				log.Tracef("dbusEventLoop: got a token len=%d", len(token))
-				needsReconnect = false
+		case event := <-d.eventChan:
+			log.Tracef("eventLoop: got event: %s", event.event)
+			switch event.event {
+			case EventReconnectRequest:
+				log.Trace("eventLoop: daemon needs to reconnect")
+				needsReconnect = true
+				if d.authorized {
+					jwtToken, serverURL, _ := client.GetJWTToken()
+					e := MenderShellDaemonEvent{
+						event: EventReconnect,
+						data:  jwtToken,
+						id:    "(eventLoop)",
+					}
+					log.Tracef("(eventLoop) posting Event: %s", e.event)
+					d.serverUrl = serverURL
+					d.postEvent(e)
+					needsReconnect = false
+				}
+			case EventReconnect:
+				err = connectionmanager.Reconnect(
+					ws.ProtoTypeShell, d.serverUrl,
+					d.deviceConnectUrl, event.data,
+					d.skipVerify, d.serverCertificate,
+					config.MaxReconnectAttempts, d.ctx,
+				)
+				if err != nil {
+					switch errors.Cause(err) {
+					case connectionmanager.ErrClientUnauthorized:
+						jwtToken, serverURL, err := client.GetJWTToken()
+						if err == nil && jwtToken != event.data {
+							// JWT changed, let's try again
+							// But let's clear any pending token-
+							// change events.
+							select {
+							case <-tokenChan:
+							default:
+							}
+							d.serverUrl = serverURL
+							err = connectionmanager.Reconnect(
+								ws.ProtoTypeShell, d.serverUrl,
+								d.deviceConnectUrl, event.data,
+								d.skipVerify, d.serverCertificate,
+								config.MaxReconnectAttempts, d.ctx,
+							)
+							if err == nil {
+								log.Trace("eventLoop: reconnected")
+								d.connectionEstChan <- MenderShellDaemonEvent{
+									event: EventConnectionEstablished,
+								}
+								continue
+							}
+						}
+						d.authorized = false
+						needsReconnect = true
+					}
+					log.Errorf("eventLoop: event: error reconnecting: %s", err.Error())
+				} else {
+					log.Trace("eventLoop: reconnected")
+					d.connectionEstChan <- MenderShellDaemonEvent{
+						event: EventConnectionEstablished,
+					}
+				}
+
 			}
-		}
-		if needsReconnect && d.authorized {
-			jwtToken, serverURL, _ := client.GetJWTToken()
-			e := MenderShellDaemonEvent{
-				event: EventReconnect,
-				data:  jwtToken,
-				id:    "(dbusEventLoop)",
-			}
-			log.Tracef("(dbusEventLoop) posting Event: %s", e.event)
-			d.serverUrl = serverURL
-			d.postEvent(e)
-			needsReconnect = false
 		}
 	}
 
-	log.Trace("dbusEventLoop: returning")
+	log.Trace("eventLoop: returning")
 }
 
 func (d *MenderShellDaemon) postEvent(event MenderShellDaemonEvent) {
@@ -353,37 +394,6 @@ func (d *MenderShellDaemon) postEvent(event MenderShellDaemonEvent) {
 
 func (d *MenderShellDaemon) readEvent() MenderShellDaemonEvent {
 	return <-d.eventChan
-}
-
-func (d *MenderShellDaemon) eventLoop() {
-	var err error
-	for {
-		if d.shouldStop() {
-			break
-		}
-
-		event := d.readEvent()
-		log.Tracef("eventLoop: got event: %s", event.event)
-		switch event.event {
-		case EventReconnect:
-			err = connectionmanager.Reconnect(
-				ws.ProtoTypeShell, d.serverUrl,
-				d.deviceConnectUrl, event.data,
-				d.skipVerify, d.serverCertificate,
-				config.MaxReconnectAttempts, d.ctx,
-			)
-			if err != nil {
-				log.Errorf("eventLoop: event: error reconnecting: %s", err.Error())
-			} else {
-				log.Trace("eventLoop: reconnected")
-				d.connectionEstChan <- MenderShellDaemonEvent{
-					event: EventConnectionEstablished,
-				}
-			}
-		}
-	}
-
-	log.Trace("eventLoop: returning")
 }
 
 func (d *MenderShellDaemon) setupLogging() {
@@ -485,8 +495,7 @@ func (d *MenderShellDaemon) Run() error {
 	}
 
 	go d.messageLoop()
-	go d.dbusEventLoop(client)
-	go d.eventLoop()
+	go d.eventLoop(client)
 
 	log.Trace("mender-connect entering main loop.")
 	for {

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -39,6 +39,11 @@ const (
 		"mender-connect.conf, or make sure that CA certificates are installed on the system"
 )
 
+type HandshakeError struct {
+	error
+	StatusCode int
+}
+
 type Connection struct {
 	writeMutex sync.Mutex
 	// the connection handler
@@ -119,8 +124,14 @@ func NewConnection(u url.URL,
 
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer "+token)
-	ws, _, err := dialer.Dial(u.String(), headers)
+	ws, rsp, err := dialer.Dial(u.String(), headers)
 	if err != nil {
+		if rsp != nil {
+			return nil, HandshakeError{
+				error:      err,
+				StatusCode: rsp.StatusCode,
+			}
+		}
 		return nil, err
 	}
 

--- a/connectionmanager/connectionmanager.go
+++ b/connectionmanager/connectionmanager.go
@@ -17,6 +17,7 @@ package connectionmanager
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -43,6 +44,7 @@ var (
 	ErrHandlerNotRegistered       = errors.New("protocol handler not registered")
 	ErrHandlerAlreadyRegistered   = errors.New("protocol handler already registered")
 	ErrConnectionRetriesExhausted = errors.New("failed to connect after max number of retries")
+	ErrClientUnauthorized         = errors.New("client unauthorized")
 )
 
 var (
@@ -90,6 +92,11 @@ func connect(proto ws.ProtoType, serverUrl, connectUrl, token string, skipVerify
 		i++
 		c, err = connection.NewConnection(u, token, writeWait, maxMessageSize, DefaultPingWait, skipVerify, serverCertificate)
 		if err != nil || c == nil {
+			if he, ok := err.(connection.HandshakeError); ok {
+				if he.StatusCode == http.StatusUnauthorized {
+					return ErrClientUnauthorized
+				}
+			}
 			if retries == 0 || i < retries {
 				if err == nil {
 					err = errors.New("unknown error: connection was nil but no error provided by connection.NewConnection")


### PR DESCRIPTION
This commit merges the dbusEventLoop and eventLoop into a single
eventLoop routine, since separating the reconnection logic can lead to
unintended short-circuit loops if the device becomes decommissioned.

changelog: title

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>