### PR TITLE
QA-347: trigger:mender-dist-packages: Set correct variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,6 +72,7 @@ trigger:mender-dist-packages:
     - if: '$CI_COMMIT_BRANCH == "master"'
   variables:
     MENDER_CONNECT_VERSION: $CI_COMMIT_REF_NAME
+    PUBLISH_MENDER_DIST_PACKAGES_AUTOMATIC: "true"
   trigger:
     project: Northern.tech/Mender/mender-dist-packages
     branch: master


### PR DESCRIPTION
To trigger the publish of packages in experimental distribution