### PR TITLE
Add couple of info logs to make logging symmetric

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -214,6 +214,7 @@ func (d *MenderShellDaemon) messageLoop() (err error) {
 			d.reconnectChan <- e
 			response := <-d.connectionEstChan
 			log.Tracef("messageLoop: got response: %+v", response)
+			log.Info("messageLoop: reconnected, continuing.")
 			continue
 		}
 
@@ -453,6 +454,7 @@ func (d *MenderShellDaemon) Run() error {
 			return err
 		}
 		d.authorized = true
+		log.Infof("got JWT token, len(JWT)=%d, continuing to main loop", len(jwtToken))
 	} else {
 		d.authorized = true
 	}


### PR DESCRIPTION
In both cases will make the whole info level logging more readable.

On start, the last message of regular operations ends with "waiting for
JWT token", so let's inform the user when the token was retrieved and
the connection is up and running.

Similarly, on re-connections, the user is left with "waiting for
reconnect", so inform the user when the re-connection happened.