### PR TITLE
assume /bin/sh as default shell when no /etc/shells file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -214,6 +214,10 @@ func isExecutable(path string) bool {
 func isInShells(path string) bool {
 	file, err := os.Open("/etc/shells")
 	if err != nil {
+		// if no /etc/shell is found, DefaultShellCommand is accepted
+		if path == DefaultShellCommand {
+			return true
+		}
 		log.Fatal(err)
 	}
 	defer file.Close()


### PR DESCRIPTION
feat: assume `/bin/sh` when deploying on platforms without `/etc/shells`

Specifically required when deploying on a platform where standard folders (including but not limited to `/etc`)  are read-only (e.g., [Berghof PLC](https://www.berghof-automation.com/en/products/compact-control-system/b-fortis-cc-slim)). On these platforms `/etc/shells` cannot be added (if missing).

Signed-off-by: Uri Ishon uishon@gmail.com












