### PR TITLE
ci: Do not inherit parent variables on child pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,8 @@ trigger:mender-qa:
 
 trigger:mender-dist-packages:
   stage: trigger
+  inherit:
+    variables: false
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
@@ -88,6 +90,8 @@ trigger:mender-dist-packages:
 
 trigger:integration:
   stage: trigger
+  inherit:
+    variables: false
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
     - if: '$CI_PIPELINE_SOURCE == "pipeline"'


### PR DESCRIPTION
So that we have full control of which variables to pass downstream by opting-in explicitly the required ones.

See: https://docs.gitlab.com/ee/ci/yaml/#inherit

Ticket: QA-352