### PR TITLE
fix(connectionmanager): Early exit on malformed Url

### DIFF
--- a/connectionmanager/connectionmanager.go
+++ b/connectionmanager/connectionmanager.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -105,6 +106,10 @@ func connect(
 				log.Errorf("connection manager failed to connect to %s%s: %s; "+
 					"reconnecting in %ds (try %d/%d); len(token)=%d", serverUrl, connectUrl,
 					err.Error(), reconnectIntervalSeconds, i, retries, len(token))
+				if strings.Contains(err.Error(), "malformed ws or wss URL") {
+					// If the given serverUrl is malformed, exit so that the caller can update it
+					return err
+				}
 				select {
 				case cancelFlag := <-cancelReconnectChan[proto]:
 					log.Tracef("connectionmanager connect got cancelFlag=%+v", cancelFlag)

--- a/connectionmanager/connectionmanager.go
+++ b/connectionmanager/connectionmanager.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -140,22 +140,6 @@ func connect(
 	}
 
 	return nil
-}
-
-func Connect(
-	proto ws.ProtoType,
-	serverUrl, connectUrl, token string,
-	retries uint,
-	ctx context.Context,
-) error {
-	handlersByTypeMutex.Lock()
-	defer handlersByTypeMutex.Unlock()
-
-	if _, exists := handlersByType[proto]; exists {
-		return ErrHandlerAlreadyRegistered
-	}
-
-	return connect(proto, serverUrl, connectUrl, token, retries, ctx)
 }
 
 func Reconnect(

--- a/connectionmanager/connectionmanager_test.go
+++ b/connectionmanager/connectionmanager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ func TestConnect(t *testing.T) {
 	_ = Close(ws.ProtoTypeShell)
 
 	ctx := context.Background()
-	err := Connect(ws.ProtoTypeShell, "ws://localhost:8999", "/ws", "token", 1, ctx)
+	err := Reconnect(ws.ProtoTypeShell, "ws://localhost:8999", "/ws", "token", 1, ctx)
 	assert.Nil(t, err)
 
 	msg, err := Read(ws.ProtoTypeShell)
@@ -137,7 +137,7 @@ func TestConnectFailed(t *testing.T) {
 	_ = Close(ws.ProtoTypeShell)
 
 	ctx := context.Background()
-	err := Connect(ws.ProtoTypeShell, "wrong-url", "/ws", "token", 1, ctx)
+	err := Reconnect(ws.ProtoTypeShell, "wrong-url", "/ws", "token", 1, ctx)
 	assert.NotNil(t, err)
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -593,7 +593,7 @@ func TestMenderShellStartStopShell(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -686,7 +686,7 @@ func TestMenderShellCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	conn, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -763,7 +763,7 @@ func TestMenderShellShellAlreadyStartedFailedToStart(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -855,7 +855,7 @@ func TestMenderShellSessionExpire(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -885,7 +885,7 @@ func TestMenderShellSessionUpdateWS(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -912,7 +912,7 @@ func TestMenderShellSessionGetByUserId(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -957,7 +957,7 @@ func TestMenderShellSessionGetById(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1013,7 +1013,7 @@ func TestMenderShellDeleteById(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1088,7 +1088,7 @@ func TestMenderShellNewMenderShellSession(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1132,7 +1132,7 @@ func TestMenderSessionTerminateExpired(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1184,7 +1184,7 @@ func TestMenderSessionTerminateAll(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1241,7 +1241,7 @@ func TestMenderSessionTerminateIdle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)

--- a/shell/exec_test.go
+++ b/shell/exec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ func TestNewMenderShellReadStdIn(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	err = connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	err = connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
 	assert.NoError(t, err)
 
 	webSock, err := connection.NewConnection(*urlString, "token", time.Second, 526, time.Second)


### PR DESCRIPTION
    Changelog: If mender-connect gets a malformed server Url from D-Bus,
    early exit the websocket connection routine so that we can attempt again
    with a correct server Url without waiting to exhaust the reconnect
    retries.