### PR TITLE
Fix limits test user name mixup

### DIFF
--- a/limits/filetransfer/limits_test.go
+++ b/limits/filetransfer/limits_test.go
@@ -388,7 +388,7 @@ func TestPermit_DownloadFile(t *testing.T) {
 	if u == nil {
 		t.Fatal("cant get current user")
 	}
-	currentUser := u.Name
+	currentUser := u.Username
 	currentGroup, _ := user.LookupGroupId(u.Gid)
 	if currentGroup == nil {
 		t.Fatal("cant get current group")
@@ -513,7 +513,7 @@ func TestPermit_UploadFile(t *testing.T) {
 	if u == nil {
 		t.Fatal("cant get current user")
 	}
-	currentUser := u.Name
+	currentUser := u.Username
 	currentGroup, _ := user.LookupGroupId(u.Gid)
 	if currentGroup == nil {
 		t.Fatal("cant get current group")


### PR DESCRIPTION
currentUser is supposed to have the current uid's username, not the descriptive field of the user (aka gecos).
Atleast that's what it gets compared against eventually.

The following two tests are affected and could sometimes give false-positives (since there's an explicit check if the user name is the empty string and then return true, which is true in some build scenarios when gecos is empty) but could also fail when gecos contained the actual users full name.

task-0:     --- FAIL: TestPermit_UploadFile/file_exists_allowed_to_overwrite_owner_match (0.00s)

task-0:     --- FAIL: TestPermit_DownloadFile/file_owner_match (0.00s)