### PR TITLE
Fix racing connection tests

### DIFF
--- a/connectionmanager/connectionmanager_test.go
+++ b/connectionmanager/connectionmanager_test.go
@@ -123,6 +123,8 @@ func TestReconnect(t *testing.T) {
 		_ = srv.Shutdown(context.Background())
 	}()
 
+	time.Sleep(2000 * time.Millisecond)
+
 	_ = Close(ws.ProtoTypeShell)
 
 	ctx := context.Background()

--- a/session/portforward_test.go
+++ b/session/portforward_test.go
@@ -218,6 +218,8 @@ func TestPortForwardHandlerSuccessfulConnection(t *testing.T) {
 		}
 	}(tcpPort)
 
+	time.Sleep(2000 * time.Millisecond)
+
 	// c1: new
 	protocol := wspf.PortForwardProtocol(wspf.PortForwardProtocolTCP)
 	remoteHost := "localhost"


### PR DESCRIPTION
The listening tcp port needs to be up before we connect or the client will end up with "connection refused".

When listen is done in a (go) thread, there's no guarantee the thread even gets to execute before the test moves on to do the connect.

Insert a sleep after thread creation in tests that has been seen to be flaky (on debian build infrastructure), hopefully long enough that the thread doing the listening gets a chance to run first.

The TestPortForwardHandlerSuccessfulConnection was reproduced locally (reliably) and the change confirmed to fix the issue there. The TestReconnect is an approximation that it's the same/similar issue and hopefully the sleep will fix it.

Relevant build logs from debian infrastructure showing the problems: https://buildd.debian.org/status/fetch.php?pkg=mender-connect&arch=ppc64el&ver=2.1.0%2Bds1-3&stamp=1673302707&raw=0 https://buildd.debian.org/status/fetch.php?pkg=mender-connect&arch=armel&ver=2.1.0%2Bds1-3&stamp=1673345986&raw=0 https://buildd.debian.org/status/fetch.php?pkg=mender-connect&arch=armhf&ver=2.1.0%2Bds1-3&stamp=1673322854&raw=0

Signed-off-by: Andreas Henriksson <andreas@fatal.se>