### PR TITLE
ci: Update unit tests job to the latest template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ test:unit:
     # start the dbus service
     - service dbus start
     # original from the gitlab-ci-check-golang-unittests.yml template
-    - go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $?
+    - go list ./... | grep -v vendor | xargs -n1 -I {} go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} 2>&1 | tee /dev/stderr | go-junit-report > ${CI_PROJECT_DIR}/test-results.xml || exit $?
     - mkdir -p tests/unit-coverage && find . -name 'coverage.txt' -exec cp --parents {} ./tests/unit-coverage \;
     - tar -cvf ${CI_PROJECT_DIR}/unit-coverage.tar tests/unit-coverage
 


### PR DESCRIPTION
So that it produces a junit report that can be parsed by CI.