### PR TITLE
feat: added back-off in connectionmanager

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -138,7 +138,6 @@ func NewDaemon(conf *config.MenderShellConfig) *MenderShellDaemon {
 		router:                  router,
 	}
 
-	connectionmanager.SetReconnectIntervalSeconds(conf.ReconnectIntervalSeconds)
 	if conf.Sessions.MaxPerUser > 0 {
 		session.MaxUserSessions = int(conf.Sessions.MaxPerUser)
 	}
@@ -389,7 +388,7 @@ func (d *MenderShellDaemon) eventLoop() {
 			err = connectionmanager.Reconnect(
 				ws.ProtoTypeShell, d.serverUrl,
 				d.deviceConnectUrl, event.data,
-				config.MaxReconnectAttempts, d.ctx,
+				d.ctx,
 			)
 			var event string
 			if err != nil {

--- a/app/daemon_test.go
+++ b/app/daemon_test.go
@@ -1,16 +1,16 @@
 // Copyright 2022 Northern.tech AS
 //
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
 //
-//        http://www.apache.org/licenses/LICENSE-2.0
+//	    http://www.apache.org/licenses/LICENSE-2.0
 //
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
 package app
 
 import (
@@ -150,8 +150,7 @@ func TestMenderShellSessionStart(t *testing.T) {
 	assert.NotNil(t, urlString)
 
 	connectionmanager.Close(ws.ProtoTypeShell)
-	connectionmanager.SetReconnectIntervalSeconds(1)
-	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	d := NewDaemon(&config.MenderShellConfig{
 		MenderShellConfigFromFile: config.MenderShellConfigFromFile{
@@ -261,8 +260,7 @@ func TestMenderShellStopByUserId(t *testing.T) {
 	assert.NotNil(t, urlString)
 
 	connectionmanager.Close(ws.ProtoTypeShell)
-	connectionmanager.SetReconnectIntervalSeconds(1)
-	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	d := NewDaemon(&config.MenderShellConfig{
 		MenderShellConfigFromFile: config.MenderShellConfigFromFile{
@@ -341,8 +339,7 @@ func TestMenderShellUnknownMessage(t *testing.T) {
 	assert.NotNil(t, urlString)
 
 	connectionmanager.Close(ws.ProtoTypeShell)
-	connectionmanager.SetReconnectIntervalSeconds(1)
-	_ = connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	_ = connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	d := NewDaemon(&config.MenderShellConfig{
 		MenderShellConfigFromFile: config.MenderShellConfigFromFile{
@@ -382,7 +379,7 @@ func newShellMulti(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//maxUserSessions controls how many sessions user can have.
+// maxUserSessions controls how many sessions user can have.
 func TestMenderShellSessionLimitPerUser(t *testing.T) {
 	session.MaxUserSessions = 2
 	currentUser, err := user.Current()
@@ -401,8 +398,7 @@ func TestMenderShellSessionLimitPerUser(t *testing.T) {
 	assert.NotNil(t, urlString)
 
 	connectionmanager.Close(ws.ProtoTypeShell)
-	connectionmanager.SetReconnectIntervalSeconds(1)
-	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	d := NewDaemon(&config.MenderShellConfig{
 		MenderShellConfigFromFile: config.MenderShellConfigFromFile{
@@ -513,8 +509,7 @@ func TestMenderShellReadMessage(t *testing.T) {
 	assert.NotNil(t, urlString)
 
 	connectionmanager.Close(ws.ProtoTypeShell)
-	connectionmanager.SetReconnectIntervalSeconds(1)
-	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	d := NewDaemon(&config.MenderShellConfig{
 		MenderShellConfigFromFile: config.MenderShellConfigFromFile{
@@ -558,8 +553,7 @@ func TestMenderShellMaxShellsLimit(t *testing.T) {
 	assert.NotNil(t, urlString)
 
 	connectionmanager.Close(ws.ProtoTypeShell)
-	connectionmanager.SetReconnectIntervalSeconds(1)
-	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 526, 16*time.Second)
 	assert.NoError(t, err)
@@ -857,7 +851,6 @@ func TestEventLoop(t *testing.T) {
 		},
 	}
 
-	connectionmanager.SetReconnectIntervalSeconds(1)
 	for _, tc := range testCases {
 		if tc.name == "run_forever" {
 			timeout := time.After(tc.timeout)
@@ -938,8 +931,7 @@ func TestMessageMainLoop(t *testing.T) {
 	assert.NotNil(t, urlString)
 
 	connectionmanager.Close(ws.ProtoTypeShell)
-	connectionmanager.SetReconnectIntervalSeconds(1)
-	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Reconnect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	webSock, err := connection.NewConnection(*urlString, "token", 8*time.Second, 526, 8*time.Second)
 	assert.NoError(t, err)

--- a/connectionmanager/exponentialbackoff.go
+++ b/connectionmanager/exponentialbackoff.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package connectionmanager
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/mendersoftware/go-lib-micro/ws"
+	log "github.com/sirupsen/logrus"
+
+	"context"
+)
+
+type expBackoff struct {
+	attempts    int
+	exceededMax bool
+	// The maximum interval before it starts increasing linearly
+	maxInterval time.Duration
+	// Retry time does not increase beyond maxBackoff
+	maxBackoff time.Duration
+	// Smallest backoff sleep time
+	smallestUnit time.Duration
+	interval     time.Duration
+}
+
+// Simple algorithm: Start with one minute, and try three times, then double
+// interval (maxInterval is maximum) and try again. Repeat until we tried
+// three times with maxInterval.
+func (a *expBackoff) GetExponentialBackoffTime() time.Duration {
+	var nextInterval time.Duration
+	const perIntervalAttempts = 3
+
+	interval := 1 * a.smallestUnit
+	nextInterval = interval << (a.attempts / perIntervalAttempts)
+	// Generates a random interval between 0 and 2 minutes
+	randomInterval := time.Duration(rand.Float64()*float64(time.Minute)) * 2
+	if nextInterval > a.maxBackoff {
+		a.attempts--
+		return a.maxBackoff + randomInterval
+	}
+
+	if nextInterval > a.maxInterval && !a.exceededMax {
+		a.exceededMax = true
+		a.attempts = 0
+	}
+
+	if a.exceededMax {
+		return a.maxInterval + (time.Duration(a.attempts) * time.Minute) + randomInterval
+	}
+	return nextInterval
+}
+
+func (a *expBackoff) WaitForBackoff(ctx context.Context, proto ws.ProtoType) error {
+	a.attempts++
+	a.interval = a.GetExponentialBackoffTime()
+
+	if a.attempts <= 1 {
+		return nil
+	}
+
+	log.Infof("connectionmanager backoff: retrying in %s", a.interval)
+
+	select {
+	case <-time.After(a.interval):
+	case <-cancelReconnectChan[proto]:
+		return context.Canceled
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (a *expBackoff) resetBackoff() {
+	a.attempts = 0
+	a.exceededMax = false
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -593,7 +593,7 @@ func TestMenderShellStartStopShell(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -686,7 +686,7 @@ func TestMenderShellCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	conn, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -763,7 +763,7 @@ func TestMenderShellShellAlreadyStartedFailedToStart(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -855,7 +855,7 @@ func TestMenderShellSessionExpire(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -885,7 +885,7 @@ func TestMenderShellSessionUpdateWS(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -912,7 +912,7 @@ func TestMenderShellSessionGetByUserId(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -957,7 +957,7 @@ func TestMenderShellSessionGetById(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1013,7 +1013,7 @@ func TestMenderShellDeleteById(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1088,7 +1088,7 @@ func TestMenderShellNewMenderShellSession(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1132,7 +1132,7 @@ func TestMenderSessionTerminateExpired(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1184,7 +1184,7 @@ func TestMenderSessionTerminateAll(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)
@@ -1240,8 +1240,8 @@ func TestMenderSessionTerminateIdle(t *testing.T) {
 	urlString, err := url.Parse(u)
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
-
-	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+ 
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)
 	assert.NoError(t, err)

--- a/shell/exec_test.go
+++ b/shell/exec_test.go
@@ -114,7 +114,7 @@ func TestNewMenderShellReadStdIn(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
 
-	err = connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", 8, nil)
+	err = connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 	assert.NoError(t, err)
 
 	webSock, err := connection.NewConnection(*urlString, "token", time.Second, 526, time.Second)


### PR DESCRIPTION
Exponentially backs off until max (5 minutes) is reached. It will then keep retrying every 5 minutes.

Changelog: Title

Ticket: MEN-5782