### PR TITLE
MEN-6858: Update sytemd service for the new client service

### DIFF
--- a/support/mender-connect.service
+++ b/support/mender-connect.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Mender Connect service
-Wants=network-online.target
-After=systemd-resolved.service network-online.target mender-client.service
-Requires=mender-client.service
+Wants=network-online.target mender-client.service mender-authd.service
+After=systemd-resolved.service network-online.target mender-client.service mender-authd.service
 
 [Service]
 Type=idle


### PR DESCRIPTION
Changelog: `mender-connect` systemd service can use either the old
`mender-client` service or the new `mender-authd` service, which is the
name of the authentication daemon of new Mender client. They are both
kept as `Wants` and not `Require` so that `mender-connect` can run with
either.