### PR TITLE
chore: Update license copyright to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2023 Northern.tech AS
+Copyright 2024 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,6 +1,6 @@
 #
 # Apache-2.0
-52b2497ce07650b825015e80ca7a5d40c360c04c530234ca6d950b0f98bca23a  LICENSE
+d0f406b04e7901e6b4076bdf5fd20f9d7f04fc41681069fd8954413ac6295688  LICENSE
 a4e99d13c6cd0e4faf3867ae5c9815ff88cab3cefdefe0dc1ec9ac28b1152944  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 #
 # BSD-2-Clause


### PR DESCRIPTION
Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 42c6ed2973fd43ae267b1f4dac5009dc606cfa2a)