### PR TITLE
chore: removed the text "mender-connect version" from --version outpu…

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -70,6 +70,13 @@ func SetupCLI(args []string) error {
 		},
 	}
 
+	cli.VersionPrinter = func(c *cli.Context) {
+		err := config.ShowVersionCLI(c)
+		if err != nil {
+			return
+		}
+	}
+
 	return app.Run(args)
 }
 


### PR DESCRIPTION
…t to be consistent

Changelog: --version no longer outputs the text "mender-connect version".

Ticket: MEN-6965