### PR TITLE
fix: Fix to make mender-connect request a new JWT token on its own, so its not dependent on mender-update to do so

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -319,21 +319,28 @@ func (d *MenderShellDaemon) dbusEventLoop(client mender.AuthClient) {
 
 		p, err := client.WaitForJwtTokenStateChange()
 		log.Tracef("dbusEventLoop: WaitForJwtTokenStateChange %v, err %v", p, err)
+
 		if len(p) > 1 &&
 			p[0].ParamType == dbus.GDBusTypeString &&
 			p[1].ParamType == dbus.GDBusTypeString {
+
 			token := p[0].ParamData.(string)
 			serverURL := p[1].ParamData.(string)
+
 			d.processJwtTokenStateChange(token, serverURL)
 			if len(token) > 0 && len(serverURL) > 0 {
 				log.Tracef("dbusEventLoop: got a token len=%d, ServerURL=%s", len(token), serverURL)
 				if token != d.serverJwt || serverURL != d.serverUrl {
-					log.Debugf(
-						"dbusEventLoop: new token or ServerURL, reconnecting. len=%d, ServerURL=%s",
-						len(token),
-						serverURL,
-					)
-					needsReconnect = true
+					e := MenderShellDaemonEvent{
+						event: EventReconnect,
+						data:  token,
+						id:    "(dbusEventLoop)",
+					}
+					d.serverJwt = token
+					d.serverUrl = serverURL
+					d.postEvent(e)
+					log.Tracef("(dbusEventLoop) posting Event: %s", e.event)
+					needsReconnect = false
 
 					// If the server (Mender client proxy) closed the connection, it is likely that
 					// both messageLoop is asking for a reconnection and we got JwtTokenStateChange
@@ -341,28 +348,18 @@ func (d *MenderShellDaemon) dbusEventLoop(client mender.AuthClient) {
 					if d.needsReconnect() {
 						log.Debug("dbusEventLoop: drained reconnect req channel")
 					}
-
 				}
-				// TODO: moving these assignments one scope up would make d.authorized redundant...
-				d.serverJwt = token
-				d.serverUrl = serverURL
 			}
 		}
-		if needsReconnect && d.authorized {
-			jwtToken, serverURL, _ := client.GetJWTToken()
-			e := MenderShellDaemonEvent{
-				event: EventReconnect,
-				data:  jwtToken,
-				id:    "(dbusEventLoop)",
+
+		if needsReconnect {
+			log.Infof("Within needsReconnect ------")
+			_, err := client.FetchJWTToken()
+			if err != nil {
+				log.Errorf("dbusEventLoop: error fetching JWT token")
 			}
-			log.Tracef("(dbusEventLoop) posting Event: %s", e.event)
-			d.serverUrl = serverURL
-			d.serverJwt = jwtToken
-			d.postEvent(e)
-			needsReconnect = false
 		}
 	}
-
 	log.Trace("dbusEventLoop: returning")
 }
 


### PR DESCRIPTION
Changelog: Fix to make `mender-connect` request a new JWT token on its own, so its not dependent on `mender-update` to do so. Previously, `mender-connect` relied the Mender client to request new JWT tokens. Since the split of mender into `mender-update` and `mender-auth`, it is theoretically possible to run mender-connect without mender-update, in which case it wouldn't request JWT tokens without this fix.

Ticket: MEN-6877