### PR TITLE
fix: systemd: Always try restarting the client if it exits.

### DIFF
--- a/support/mender-connect.service
+++ b/support/mender-connect.service
@@ -8,7 +8,7 @@ Type=idle
 User=root
 Group=root
 ExecStart=/usr/bin/mender-connect daemon
-Restart=on-abort
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Just applying the same logic as 857bae996f544a6abc67ec6ca748787b2e98e604 from the mender client repository. It can prevent the service not to be triggered due to a corner case.

Changelog: Title
Ticket: None