### PR TITLE
chore: add `-trimpath` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ VERSION = $(shell git describe --tags --dirty --exact-match 2>/dev/null || git r
 GO_LDFLAGS = \
 	-ldflags "-X github.com/mendersoftware/mender-connect/config.Version=$(VERSION)"
 
+GO_BUILDFLAGS = -trimpath
+
 ifeq ($(V),1)
 BUILDV = -v
 endif
@@ -46,7 +48,7 @@ clean:
 	@-rm -f coverage.txt
 
 mender-connect: $(PKGFILES)
-	@$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+	@$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS) $(GO_BUILDFLAGS)
 
 install: install-bin install-systemd
 


### PR DESCRIPTION
Removes system paths from the binary.

Ticket: MEN-7275