### PR TITLE
feat: lower backoff intervals

### DIFF
--- a/connectionmanager/connectionmanager.go
+++ b/connectionmanager/connectionmanager.go
@@ -66,11 +66,10 @@ func GetWriteTimeout() time.Duration {
 }
 
 var a *expBackoff = &expBackoff{
-	maxInterval:  60 * time.Minute,
-	attempts:     0,
-	exceededMax:  false,
-	maxBackoff:   120 * time.Minute,
-	smallestUnit: time.Minute,
+	attempts: 0,
+	// Set max backoff to 30 minutes
+	maxBackoff:   1800 * time.Second,
+	smallestUnit: time.Second,
 }
 
 func connect(


### PR DESCRIPTION
The previous backoff had a starting interval at 1
minute and a max backoff at 60 minutes. When it reached 60 minutes it
would linearly increase to 120 minutes minutes where it would keep
retrying.

The backoff will now start at 1 second and exponentially increase after
3 retries until it reaches 30 minutes where it will keep retrying.
For each interval a jitter between 0 and 5 seconds will be added.

Ticket: ME-546
Changelog: Commit