### PR TITLE
fix: preserve group assignments

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -438,6 +438,8 @@ func (d *MenderShellDaemon) DecreaseSpawnedShellsCount(shellStoppedCount uint) {
 //   - gets the JWT token from the mender-client via dbus (client.GetJWTToken())
 //   - connects to the backend and returns a new websocket (deviceconnect.Connect(...))
 //   - starts the message flow between the shell and websocket (shell.NewMenderShell(...))
+//
+// nolint: gocyclo
 func (d *MenderShellDaemon) Run() error {
 	d.setupLogging()
 

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -74,6 +74,7 @@ type MenderShellDaemon struct {
 	terminalString          string
 	uid                     uint64
 	gid                     uint64
+	gids                    []uint32
 	homeDir                 string
 	shellsSpawned           uint
 	debug                   bool
@@ -447,6 +448,21 @@ func (d *MenderShellDaemon) Run() error {
 	}
 	if err != nil {
 		return err
+	}
+
+	gids, err := u.GroupIds()
+	if err != nil {
+		return errors.New("unknown error while getting group ids")
+	}
+
+	// Convert []string to []uint32
+	d.gids = make([]uint32, len(gids))
+	for i, g := range gids {
+		gid, err := strconv.ParseUint(g, 10, 32)
+		if err != nil {
+			return fmt.Errorf("failed to parse group id %q: %w", g, err)
+		}
+		d.gids[i] = uint32(gid)
 	}
 
 	d.homeDir = u.HomeDir

--- a/app/daemon_shell.go
+++ b/app/daemon_shell.go
@@ -88,6 +88,7 @@ func (d *MenderShellDaemon) routeMessageSpawnShell(message *ws.ProtoMsg) error {
 	if err = s.StartShell(s.GetId(), session.MenderShellTerminalSettings{
 		Uid:            uint32(d.uid),
 		Gid:            uint32(d.gid),
+		Gids:           d.gids,
 		Shell:          d.shell,
 		HomeDir:        d.homeDir,
 		TerminalString: d.terminalString,

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1240,7 +1240,7 @@ func TestMenderSessionTerminateIdle(t *testing.T) {
 	urlString, err := url.Parse(u)
 	assert.NoError(t, err)
 	assert.NotNil(t, urlString)
- 
+
 	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
 
 	ws, err := connection.NewConnection(*urlString, "token", 16*time.Second, 256, 16*time.Second)

--- a/session/shell.go
+++ b/session/shell.go
@@ -76,6 +76,7 @@ var (
 type MenderShellTerminalSettings struct {
 	Uid            uint32
 	Gid            uint32
+	Gids           []uint32
 	Shell          string
 	HomeDir        string
 	TerminalString string
@@ -342,6 +343,7 @@ func (s *MenderShellSession) StartShell(
 	pid, pseudoTTY, cmd, err := shell.ExecuteShell(
 		terminal.Uid,
 		terminal.Gid,
+		terminal.Gids,
 		terminal.HomeDir,
 		terminal.Shell,
 		terminal.TerminalString,

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -30,6 +30,7 @@ const defaultCmdDir = "/"
 
 func ExecuteShell(uid uint32,
 	gid uint32,
+	gids []uint32,
 	homeDir string,
 	shell string,
 	termString string,
@@ -49,7 +50,7 @@ func ExecuteShell(uid uint32,
 	//if our uid is 0
 	if currentUser.Uid == "0" {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
-		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
+		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid, Groups: gids}
 	}
 
 	if _, err := os.Stat(homeDir); !os.IsNotExist(err) {


### PR DESCRIPTION
Changelog: Preserve group assignments by retrieving GIDs for users and adding them when executing a shell.
Ticket: ME-530