### PR TITLE
ci: add qa-common retry and runner defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,14 @@ include:
     file: '.gitlab-ci-check-license.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
+  - project: Northern.tech/Mender/mendertesting
+    file:
+      - qa-common/runner.yml
+      - qa-common/retry.yml
+
+default:
+  tags: !reference [.qa-common-default-runner, tags]
+  retry: !reference [.qa-common-default-retry, retry]
 
 test:unit:
   stage: test
@@ -40,6 +48,7 @@ test:backwards-compatibility:
   image: golang:1.17.13-bullseye
   needs: []
   before_script:
+    - !reference [.qa-common-network-go-retry, before_script]
     - apt-get update && apt-get install --quiet --assume-yes $(cat deb-requirements.txt )
   script:
     - go build


### PR DESCRIPTION
Include qa-common/runner.yml and qa-common/retry.yml from mendertesting to apply a consistent .qa-common-default-runner tag and .qa-common-default-retry policy to all jobs pipeline-wide.

Add network probes (apt/go/git-clone) to jobs that perform network operations, so transient failures trigger a retry instead of a hard fail.

Ticket: QA-1490