### PR TITLE
ci(test): test Codecov GitHub App integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ include:
     file: '.gitlab-ci-check-golang-lint.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-unittests.yml'
+    ref: 'fix/QA-1574-codecov-pass-sha'
   - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-license.yml'


### PR DESCRIPTION
## Summary

- Bumps mendertesting unit tests template to point at `fix/QA-1574-codecov-pass-sha` branch
- This is a test PR to verify the Codecov GitHub App posts coverage comments

## Test plan

- [ ] Verify GitLab pipeline runs `publish:unittests` successfully
- [ ] Verify Codecov GitHub App posts a coverage comment on this PR

Ticket: QA-1574