### PR TITLE
ci(coverage): switch to new codecov CLI coverage template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,7 @@ stages:
 include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-lint.yml'
-  - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-golang-unittests.yml'
+  - component: gitlab.com/Northern.tech/Mender/mendertesting/golang-unittests-codecov@feat/QA-1574-new-codecov-templates
   - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
   - component: gitlab.com/Northern.tech/Mender/mendertesting/backwards-compatible-yocto@master
   - project: 'Northern.tech/Mender/mendertesting'


### PR DESCRIPTION
- Replaces `.gitlab-ci-check-golang-unittests.yml` with `.gitlab-ci-check-golang-unittests-codecov.yml`
- New template (from mendertesting#485) uses the updated Codecov CLI with `upload-process`, explicit `--sha`, and SHA256 binary verification
- Temporary `ref:` pin to the mendertesting feature branch — to be removed once mendertesting#485 is merged

Ticket: QA-1574