### PR TITLE
[Cherry 2.2.x]: chore: Use a gitlab component for checking yocto GO build compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ include:
     file: '.gitlab-ci-check-golang-unittests.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits.yml'
+  - component: gitlab.com/Northern.tech/Mender/mendertesting/backwards-compatible-yocto@master
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-license.yml'
   - project: 'Northern.tech/Mender/mendertesting'
@@ -36,15 +37,6 @@ build:make:
     - apk add --update git make gcc pkgconfig libc-dev glib-dev
   script:
     - make build
-
-# Test that we can build with the golang version of the oldest supported yocto LTS release
-test:backwards-compatibility:
-  image: golang:1.17.13-bullseye
-  needs: []
-  before_script:
-    - apt-get update && apt-get install --quiet --assume-yes $(cat deb-requirements.txt )
-  script:
-    - go build
 
 generate-qa-trigger:
   image: python:alpine

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 Northern.tech AS
+Copyright 2026 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,6 +1,6 @@
 #
 # Apache-2.0
-38791d93beae962b266e11ac888ea2af4f07578b272c2f9dcb05f54f32960a76  LICENSE
+d7e8fd4ad05371007d60285c309ba7a7ce3e61029b843f949fbb9ec79dc9eb47  LICENSE
 a4e99d13c6cd0e4faf3867ae5c9815ff88cab3cefdefe0dc1ec9ac28b1152944  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 #
 # BSD-2-Clause


### PR DESCRIPTION
Ticket: MEN-9689


(cherry picked from commit 39720dd614a308a21fcd30fd842e03d6d80407fc)