### PR TITLE
ci: Use test:unit from mendertesting template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,16 +24,6 @@ default:
   tags: !reference [.qa-common-default-runner, tags]
   retry: !reference [.qa-common-default-retry, retry]
 
-test:unit:
-  stage: test
-  script:
-    # start the dbus service
-    - service dbus start
-    # original from the gitlab-ci-check-golang-unittests.yml template
-    - go list ./... | grep -v vendor | xargs -n1 -I {} go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} 2>&1 | tee /dev/stderr | go-junit-report > ${CI_PROJECT_DIR}/test-results.xml || exit $?
-    - mkdir -p tests/unit-coverage && find . -name 'coverage.txt' -exec cp --parents {} ./tests/unit-coverage \;
-    - tar -cvf ${CI_PROJECT_DIR}/unit-coverage.tar tests/unit-coverage
-
 build:make:
   stage: build
   needs: []


### PR DESCRIPTION
mender-connect had a local implementation of golang coverage test. Instead the one from the template shall be used - the same way as in other repositories.