### PR TITLE
fix: Do not block the message loop when a late pong arrives

### DIFF
--- a/session/shell.go
+++ b/session/shell.go
@@ -161,7 +161,7 @@ func NewMenderShellSession(
 		sessionType: ShellInteractiveSession,
 		status:      NewSession,
 		stop:        make(chan struct{}),
-		pong:        make(chan struct{}),
+		pong:        make(chan struct{}, 1),
 	}
 	sessionsMap[sessionId] = s
 	sessionsByUserIdMap[userId] = append(sessionsByUserIdMap[userId], s)
@@ -444,7 +444,14 @@ func (s *MenderShellSession) healthcheckPing() {
 }
 
 func (s *MenderShellSession) HealthcheckPong() {
-	s.pong <- struct{}{}
+	// The healthcheck goroutine stops reading this channel once it takes its
+	// timeout branch, but the session can still be looked up for a while, so
+	// a blocking send here could leave the daemon's messageLoop waiting
+	// forever on a late pong.
+	select {
+	case s.pong <- struct{}{}:
+	default:
+	}
 }
 
 func (s *MenderShellSession) ShellCommand(m *ws.ProtoMsg) error {

--- a/session/shell_test.go
+++ b/session/shell_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os/user"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mendersoftware/go-lib-micro/ws"
+
+	"github.com/mendersoftware/mender-connect/connectionmanager"
+)
+
+// onMessage fires fn in a new goroutine the first time a log line containing
+// substr is emitted.
+type onMessage struct {
+	substr string
+	once   sync.Once
+	fn     func()
+}
+
+func (h *onMessage) Levels() []log.Level { return log.AllLevels }
+
+func (h *onMessage) Fire(e *log.Entry) error {
+	if strings.Contains(e.Message, h.substr) {
+		h.once.Do(func() { go h.fn() })
+	}
+	return nil
+}
+
+func mustNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func mustNotNil(t *testing.T, s *MenderShellSession) {
+	t.Helper()
+	if s == nil {
+		t.Fatal("session is nil")
+	}
+}
+
+func allGoroutines() string {
+	buf := make([]byte, 1<<20)
+	return string(buf[:runtime.Stack(buf, true)])
+}
+
+func startHealthcheckTestSession(t *testing.T, sessionID, userID string) *MenderShellSession {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(newShellTransaction))
+	t.Cleanup(server.Close)
+	u := "ws" + strings.TrimPrefix(server.URL, "http")
+	connectionmanager.Connect(ws.ProtoTypeShell, u, "/", "token", nil)
+
+	currentUser, err := user.Current()
+	mustNoErr(t, err)
+	uid, err := strconv.ParseUint(currentUser.Uid, 10, 32)
+	mustNoErr(t, err)
+	gid, err := strconv.ParseUint(currentUser.Gid, 10, 32)
+	mustNoErr(t, err)
+
+	s, err := NewMenderShellSession(sessionID, userID, defaultSessionExpiredTimeout, NoExpirationTimeout)
+	mustNoErr(t, err)
+	mustNotNil(t, s)
+
+	err = s.StartShell(sessionID, MenderShellTerminalSettings{
+		Uid:            uint32(uid),
+		Gid:            uint32(gid),
+		Shell:          "/bin/sh",
+		TerminalString: "xterm-256color",
+		Height:         40,
+		Width:          80,
+	})
+	mustNoErr(t, err)
+	return s
+}
+
+// shortenHealthcheck reduces the 60s+5s healthcheck timers so the test does not
+// have to wait 65 seconds.  It does not touch the 4 second window inside
+// procps.TerminateAndWait, which is what the failure actually needs.
+func shortenHealthcheck(t *testing.T) {
+	t.Helper()
+	origInterval, origTimeout := healthcheckInterval, healthcheckTimeout
+	healthcheckInterval = 1 * time.Second
+	healthcheckTimeout = 1 * time.Second
+	t.Cleanup(func() {
+		healthcheckInterval, healthcheckTimeout = origInterval, origTimeout
+	})
+}
+
+// isolateLogHooks removes the test's log hooks when it finishes; logrus has no
+// RemoveHook.
+func isolateLogHooks(t *testing.T) {
+	t.Helper()
+	orig := log.StandardLogger().ReplaceHooks(make(log.LevelHooks))
+	t.Cleanup(func() {
+		log.StandardLogger().ReplaceHooks(orig)
+	})
+}
+
+// pongRoute performs exactly what app.(*MenderShellDaemon).routeMessagePongShell
+// does on the messageLoop goroutine.
+func pongRoute(sessionID string) error {
+	s := MenderShellSessionGetById(sessionID)
+	if s == nil {
+		return ErrSessionNotFound
+	}
+	s.HealthcheckPong()
+	return nil
+}
+
+// TestLatePongDuringHealthcheckStop delivers a pong while the healthcheck
+// goroutine is stopping its own session.  The healthcheck goroutine stops
+// reading s.pong the moment it logs "health check failed", but the session
+// stays in sessionsMap until MenderShellStopById finishes, at least 4 seconds
+// later, because procps.TerminateAndWait sleeps 2s + 2s unconditionally.  A
+// pong delivered in that window must not block: HealthcheckPong is called
+// synchronously from the daemon's messageLoop goroutine, so a blocking send
+// leaves the daemon waiting forever on a channel that no longer has a reader.
+func TestLatePongDuringHealthcheckStop(t *testing.T) {
+	MaxUserSessions = 2
+	shortenHealthcheck(t)
+	isolateLogHooks(t)
+
+	const sessionID = "11111111-1111-1111-1111-111111111111"
+	returned := make(chan error, 1)
+	stopped := make(chan struct{})
+
+	// The healthcheck goroutine logs "health check failed" from inside the
+	// timeout branch of its select.  From that point it never reads s.pong
+	// again, but the session stays in sessionsMap until MenderShellStopById
+	// finishes, at least 4 seconds later.
+	log.AddHook(&onMessage{substr: sessionID + ", health check failed", fn: func() {
+		returned <- pongRoute(sessionID)
+	}})
+	log.AddHook(&onMessage{substr: sessionID + " successfully stopped", fn: func() {
+		close(stopped)
+	}})
+
+	startHealthcheckTestSession(t, sessionID, "user-late-pong")
+
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("routeMessagePongShell did not return: the messageLoop goroutine is "+
+			"blocked on the pong channel.\n\n%s", allGoroutines())
+	}
+
+	// Wait for MenderShellStopById to finish, so the healthcheck goroutine and
+	// its sessionsMap removal do not outlive the test.
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("session stop did not finish\n\n%s", allGoroutines())
+	}
+}
+
+// TestPongAfterSessionDeleted is the negative control.  A pong that arrives
+// after MenderShellStopById removed the session is rejected with
+// ErrSessionNotFound and does not block, which shows the failure above is
+// caused by the timing of the send and not by the harness itself.
+func TestPongAfterSessionDeleted(t *testing.T) {
+	MaxUserSessions = 2
+	shortenHealthcheck(t)
+	isolateLogHooks(t)
+
+	const sessionID = "22222222-2222-2222-2222-222222222222"
+	returned := make(chan error, 1)
+
+	// "successfully stopped" is logged after MenderShellDeleteById has run.
+	log.AddHook(&onMessage{substr: sessionID + " successfully stopped", fn: func() {
+		returned <- pongRoute(sessionID)
+	}})
+
+	startHealthcheckTestSession(t, sessionID, "user-pong-control")
+
+	select {
+	case err := <-returned:
+		if err != ErrSessionNotFound {
+			t.Fatalf("expected ErrSessionNotFound, got %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("negative control blocked, the harness is wrong\n\n%s", allGoroutines())
+	}
+}


### PR DESCRIPTION
## Problem

A single remote-terminal session whose healthcheck times out can permanently hang the whole mender-connect daemon.

`MenderShellSession.pong` is an unbuffered channel whose only reader is the `select` in the `healthcheck` goroutine. When the healthcheck times out, that goroutine logs `health check failed`, calls `MenderShellStopById` and returns — from that point on the channel has no reader.

The session, however, stays reachable through `MenderShellSessionGetById` until `MenderShellStopById` finishes removing it. Removal takes at least four seconds, because `procps.TerminateAndWait` unconditionally runs `SIGTERM → sleep 2s → SIGKILL → sleep 2s`. So a normal healthcheck-timeout stop opens a removal window of at least four seconds in which a late pong finds the session and `HealthcheckPong()` blocks forever on the channel send.

`HealthcheckPong()` is called synchronously on the message-loop path (`messageLoop` → `routeMessage` → `routeMessagePongShell`), so the blocked send hangs the daemon's message loop: the daemon stops reading the websocket, goes silent in the logs, and never reconnects. The process stays alive, so systemd's `Restart=always` never fires. Remote terminal connections from the Mender UI then fail (`WebSocket error: Unknown error` in the Troubleshooting tab) until mender-connect is restarted manually.

We hit this in production — remote access to a field device was lost for three days until a manual restart — and we can reproduce it on demand on a real device against hosted Mender by delaying a single pong so that it arrives inside the removal window. Goroutine dump of the hung daemon (from a 2.3.2-based binary; line numbers on current master differ only in the two `daemon.go` frames):

```
goroutine 36 [chan send, 4 minutes]:
runtime.chansend1(...)
github.com/mendersoftware/mender-connect/session.(*MenderShellSession).HealthcheckPong(...)
	github.com/mendersoftware/mender-connect/session/shell.go:447
github.com/mendersoftware/mender-connect/app.(*MenderShellDaemon).routeMessagePongShell(...)
	github.com/mendersoftware/mender-connect/app/daemon_shell.go:264
github.com/mendersoftware/mender-connect/app.(*MenderShellDaemon).routeMessage(...)
	github.com/mendersoftware/mender-connect/app/daemon.go:579
github.com/mendersoftware/mender-connect/app.(*MenderShellDaemon).messageLoop(...)
	github.com/mendersoftware/mender-connect/app/daemon.go:256
```

The dump also shows that the `healthcheck` goroutine that would read the pong no longer exists, so this send can never complete.

## Affected versions

All versions since 1.1.0 (April 2021) are affected, up to and including current master: the unbuffered send is unchanged across this range, and we reproduced the blocked send on eleven tags from 1.1.0 through master.

## Fix

Give `pong` a single slot and make the send non-blocking. A pong only signals that the peer is alive, so holding one is enough and dropping a second one changes nothing. The buffer keeps a pong that arrives while the healthcheck is momentarily outside its `select`; the `default` keeps the sender from blocking once the reader is gone.

## Testing

- New `session/shell_test.go`:
  - `TestLatePongDuringHealthcheckStop` delivers a pong right after `health check failed` is logged, i.e. inside the removal window. Without the fix it fails after 30 s with the sending goroutine blocked at `session/shell.go:447`; with the fix it passes. The trigger is event-driven (a log hook), not sleep-based, and the window it relies on is at least four seconds wide, so it is not sensitive to scheduling.
  - `TestPongAfterSessionDeleted` (negative control): a pong delivered after the removal is rejected with `ErrSessionNotFound` and never blocks.
- The two tests add roughly 12 s of wall time to the suite.
- Note: `go test -race ./session` fails on master even without this patch (pre-existing data races); CI runs without `-race`.
- Verified on a real device (a 2.3.2-based binary with this patch, against hosted Mender): the patched binary survives the same late-pong injection that reliably hangs the unpatched one, and keeps accepting new terminal sessions afterwards.

We ship mender-connect from the 2.3.x series, so we would appreciate a backport to the maintained release branches. The patch applies cleanly there: `session/shell.go` is the same blob on master, 2.3.x and 3.0.x.
